### PR TITLE
fix: airwave-host-32 build

### DIFF
--- a/src/host/CMakeLists.txt
+++ b/src/host/CMakeLists.txt
@@ -65,7 +65,7 @@ if(NOT DISABLE_32BIT)
 
     set_target_properties(${TARGET_NAME}-32 PROPERTIES
             COMPILE_FLAGS "-m32"
-            LINK_FLAGS "-m32"
+            LINK_FLAGS "-m32 -L /usr/lib/i386-linux-gnu/wine"
     )
 
     # Link with libraries


### PR DESCRIPTION
Can't compile airwave-host-32: cmake can't find installed in /usr/lib/i386-linux-gnu/wine libs.

Error message:
```
[ 30%] Building CXX object src/host/CMakeFiles/airwave-host-32.dir/main.cpp.o
[ 32%] Linking CXX executable airwave-host-32
ld: relocatable linking with relocations from format elf64-x86-64 (/usr/lib/x86_64-linux-gnu/wine/libwinecrt0.a(exe_entry.o)) to format elf32-i386 (airwave-host-32.0GjNO7.o) is not supported
winebuild: ld failed with status 1
winegcc: /usr/lib/wine/winebuild failed
```

Command:
```
    mkdir -p build && cd build && \
    cmake \
        -DCMAKE_BUILD_TYPE="Release" \
        -DCMAKE_INSTALL_PREFIX=/opt/airwave \
        ..
```

Related links:

https://github.com/phantom-code/airwave/issues/65
https://github.com/LMMS/lmms/issues/3582

OS: Ubuntu 18.10

Packages:
```
sudo apt install -y git cmake gcc-multilib build-essential qt5-qmake qtbase5-dev libmagic-dev libwine-dev libwine-dev:i386
```