### PR TITLE
audioMasterProcessEvents deadlock and crash on plugin/window close fixes.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,7 @@ endif()
 
 # Set compiler flags
 if(${CMAKE_CXX_COMPILER_ID} MATCHES "GNU" OR ${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
-	set(CMAKE_CXX_FLAGS "-std=c++11 -Wall -Wextra")
+	set(CMAKE_CXX_FLAGS "-std=c++11 -Wall -Wextra -fpermissive")
 	set(CMAKE_CXX_FLAGS_DEBUG "-O0 -g3")
 	set(CMAKE_CXX_FLAGS_RELEASE "-O3")
 	set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O3 -g3")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,3 +72,4 @@ include_directories(
 add_subdirectory(src/plugin)
 add_subdirectory(src/host)
 add_subdirectory(src/manager)
+add_subdirectory(src/tester)

--- a/README.md
+++ b/README.md
@@ -52,6 +52,14 @@ Of course, you can change the ``CMAKE_INSTALL_PREFIX`` as you like. Note that ai
 
 **Note:** After you have created the link you cannot move/rename it with a file manager. All updates have to be done inside the airwave-manager. Also, you should update your links after updating the airwave itself. This could be achived by pressing the "Update links" button.
 
+## Wine compabilities issues
+If the plugin cannot be scan by your host, it is possible to use the ```airwave-tester``` and pass WINEDEBUG flags to have a better idea what is the issue with the plugin.
+
+```
+export WINEDEBUG=fixme-all,warn+all
+/opt/airwave/bin/airwave-tester '~/.vst/DUNE 3.so'
+```
+
 ## Under the hood
 The bridge consists of four components:
 - Plugin endpoint (airwave-plugin.so)

--- a/README.md
+++ b/README.md
@@ -78,12 +78,14 @@ If you will get success with another version, please contact me and I will updat
  AlgoMusic CZynthia | yes |
  Aly James LAB OB-Xtreme | yes |
  Analogic Delay by interrruptor | yes |
+ Audio Damage Dubstation 2 | yes |
  Bionic Delay by interrruptor | yes |
  Blue Cat Audio Oscilloscope Multi | no | doesn't work with wine
-  Cableguys Volume Shaper | yes | you need to install native d2d1.dll and override it in winecfg
+ Cableguys Volume Shaper | yes | you need to install native d2d1.dll and override it in winecfg
  Credland Audio BigKick | yes | you need to install native d2d1.dll and override it in winecfg
  FabFilter plugins | yes | haven't tested them all
  Green Oak Software Crystal | yes |
+ IK Multimedia Amplitude 4 | yes |
  Image-Line Harmless | yes |
  Image-Line Sytrus | yes |
  Image-Line Drummaxx | yes |
@@ -124,5 +126,6 @@ If you will get success with another version, please contact me and I will updat
  u-he plugins | yes | Linux version is also available
  Variety of Sound plugins | yes |
  Voxengo plugins | mostly | inter plugin routing doesn't work (architecture issue)
+ Valhalla VintageVerb | yes |
  Xfer Serum | yes | install native GDI+ (run `winetricks gdiplus`)
  EZDrummer2, BFD3, XLN AD2 | yes | host need multi-channel support

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ If you will get success with another version, please contact me and I will updat
  Cableguys Volume Shaper | yes | you need to install native d2d1.dll and override it in winecfg
  Credland Audio BigKick | yes | you need to install native d2d1.dll and override it in winecfg
  FabFilter plugins | yes | haven't tested them all
+ GForce impOSCar2 | yes |
  Green Oak Software Crystal | yes |
  IK Multimedia Amplitude 4 | yes |
  Image-Line Harmless | yes |
@@ -120,6 +121,7 @@ If you will get success with another version, please contact me and I will updat
  SuperWave P8 | yes |
  Synapse Audio DUNE 2 | yes |
  Synth1 by Ichiro Toda | yes |
+ TAL TAL-U-NO-LX | yes |
  Tone2 FireBird | yes |
  Tone2 Nemesis | yes |
  Tone2 Saurus | yes |

--- a/src/common/dataport.cpp
+++ b/src/common/dataport.cpp
@@ -6,7 +6,6 @@
 #include <sys/stat.h>
 #include "common/logger.h"
 
-
 namespace Airwave {
 
 
@@ -15,6 +14,7 @@ DataPort::DataPort() :
 	frameSize_(0),
 	buffer_(nullptr)
 {
+	wait_softlimit = 30000;
 }
 
 
@@ -152,15 +152,35 @@ void DataPort::sendResponse()
 }
 
 
-bool DataPort::waitRequest(int msecs)
+bool DataPort::waitRequest(const char *debugObject, int msecs)
 {
-	return controlBlock()->request.wait(msecs);
+	if ( msecs == -1 ) 
+	{
+		if ( !controlBlock()->request.wait(wait_softlimit) ) 
+		{
+			ERROR("waitRequest FAILED for %s", debugObject);
+			return false;
+		}
+		return true;
+	} else {
+		return controlBlock()->request.wait(msecs);
+	}
 }
 
 
-bool DataPort::waitResponse(int msecs)
+bool DataPort::waitResponse(const char *debugObject, int msecs)
 {
-	return controlBlock()->response.wait(msecs);
+	if ( msecs == -1 ) 
+	{
+		if ( !controlBlock()->response.wait(wait_softlimit) ) 
+		{
+			ERROR("waitResponse FAILED for %s", debugObject);
+			return false;
+		}
+		return true;
+	} else {
+		return controlBlock()->response.wait(msecs);
+	}
 }
 
 

--- a/src/common/dataport.h
+++ b/src/common/dataport.h
@@ -30,8 +30,8 @@ public:
 	void sendRequest();
 	void sendResponse();
 
-	bool waitRequest(int msecs = -1);
-	bool waitResponse(int msecs = -1);
+	bool waitRequest(const char *debugObject, int msecs = -1);
+	bool waitResponse(const char *debugObject, int msecs = -1);
 
 private:
 	struct ControlBlock {
@@ -44,6 +44,10 @@ private:
 	void* buffer_;
 
 	ControlBlock* controlBlock();
+
+	// if the waitRequest or waitResponse is asking for -1; we impose a soft limit to avoid host lock on 
+	// dsp thread
+	int wait_softlimit;
 };
 
 

--- a/src/common/framequeue.h
+++ b/src/common/framequeue.h
@@ -1,0 +1,57 @@
+#pragma once
+
+#include <sys/ipc.h>
+#include <sys/msg.h>
+
+#include "common/types.h"
+#include "common/protocol.h"
+#include "common/logger.h"
+#include <string.h>
+
+namespace Airwave {
+
+class FrameQueue {
+    int msgid_;
+public:
+    FrameQueue() {
+        msgid_ = -1;
+    }
+
+    ~FrameQueue() {
+        if ( msgid_ > 0 )
+            msgctl(msgid_, IPC_RMID, 0);
+    }
+
+    bool connect(int id) {
+        msgid_ = msgget(id, 0600 | IPC_CREAT);
+        if (msgid_ == -1) {
+            ERROR("Unable to connect FrameQueue port (id = %d)", id);
+            return false;
+		}
+        return true;
+    }
+
+    void pushFrame(DataFrame *frame) {
+        Message msg;
+        memcpy(&(msg.data), frame, CALLBACK_FRAMESIZE);
+        if ( msgsnd(msgid_, &msg, CALLBACK_FRAMESIZE, IPC_NOWAIT) == -1 ) {
+            ERROR("Error sending message %s", strerror(errno));
+        }
+    }
+
+    bool popFrame(DataFrame *frame) {
+        if ( msgrcv(msgid_, frame, CALLBACK_FRAMESIZE, 0, IPC_NOWAIT) == -1 )
+            return false;
+        return true;
+    }
+    // This is standard Linux msg size from /proc/sys/kernel/msgmax
+    static const int CALLBACK_FRAMESIZE = 8192;
+private:
+    struct Message {
+        Message() { mtype = 1; }
+        long mtype;
+        u8   data[FrameQueue::CALLBACK_FRAMESIZE];
+    };
+};
+
+}

--- a/src/host/CMakeLists.txt
+++ b/src/host/CMakeLists.txt
@@ -21,6 +21,9 @@ set(CMAKE_SYSTEM_NAME Windows)
 set(CMAKE_C_COMPILER winegcc)
 set(CMAKE_CXX_COMPILER wineg++)
 
+# Debug code should contain Windows symbol on the Wine side...
+set(CMAKE_CXX_FLAGS_DEBUG "-O0 -gstabs")
+
 add_definitions(-DNOMINMAX)
 
 if(DEBUG_BINARY_DIR)

--- a/src/host/CMakeLists.txt
+++ b/src/host/CMakeLists.txt
@@ -51,6 +51,7 @@ if(NOT DISABLE_64BIT AND PLATFORM_64BIT)
     # Link with libraries
     target_link_libraries(${TARGET_NAME}-64
             ${CMAKE_THREAD_LIBS_INIT}
+            ${X11_X11_LIB}            
     )
 
     install(PROGRAMS
@@ -71,7 +72,8 @@ if(NOT DISABLE_32BIT)
     # Link with libraries
     target_link_libraries(${TARGET_NAME}-32
             ${CMAKE_THREAD_LIBS_INIT}
-    )
+            ${X11_X11_LIB}
+    )    
 
     install(PROGRAMS
             ${CMAKE_CURRENT_BINARY_DIR}/${TARGET_NAME}-32.exe

--- a/src/host/host.cpp
+++ b/src/host/host.cpp
@@ -4,6 +4,7 @@
 #include "common/logger.h"
 #include "common/protocol.h"
 
+#include <X11/Xlib.h>
 
 namespace Airwave {
 
@@ -225,10 +226,14 @@ std::string Host::errorString() const
 void Host::destroyEditorWindow()
 {
 	if(hwnd_) {
+		Display *display = XOpenDisplay(0);
 		KillTimer(hwnd_, timerId_);
+		XSync(display, true);
 		DestroyWindow(hwnd_);
 		UnregisterClass(kWindowClass, GetModuleHandle(nullptr));
 		hwnd_ = 0;
+		XSync(display, true);
+		XCloseDisplay(display);
 	}
 }
 

--- a/src/host/host.h
+++ b/src/host/host.h
@@ -10,7 +10,7 @@
 #include "common/event.h"
 #include "common/vst24.h"
 #include "common/vsteventkeeper.h"
-
+#include "common/framequeue.h"
 
 namespace Airwave {
 
@@ -43,6 +43,9 @@ private:
 	DataPort controlPort_;
 	DataPort callbackPort_;
 	DataPort audioPort_;
+
+    i64 audiotid_;
+	FrameQueue audioCallback_;
 
 	Event condition_;
 

--- a/src/host/main.cpp
+++ b/src/host/main.cpp
@@ -8,12 +8,12 @@
 using namespace Airwave;
 
 
-int main(int argc, const char* argv[])
+int __cdecl main(int argc, const char* argv[])
 {
 	if(argc != 5) {
-		fprintf(stderr, "Airwave host endpoint, version " VERSION_STRING);
-		fprintf(stderr, "error: wrong number of arguments: %d", argc);
-		fprintf(stderr, "usage: %s <vst path> <port id> <log level> <log socket path>",
+		fprintf(stderr, "Airwave host endpoint, version " VERSION_STRING "\n");
+		fprintf(stderr, "error: wrong number of arguments: %d\n", argc);
+		fprintf(stderr, "usage: %s <vst path> <port id> <log level> <log socket path>\n",
 				argv[0]);
 
 		loggerFree();

--- a/src/plugin/main.cpp
+++ b/src/plugin/main.cpp
@@ -19,7 +19,7 @@ AEffect* mainStub(AudioMasterProc audioMasterProc) asm ("main");
 
 }
 
-
+/* for now this is not needed.
 void signalHandler(int signum)
 {
 	if(signum == SIGCHLD) {
@@ -29,7 +29,7 @@ void signalHandler(int signum)
 		TRACE("Received signal %d", signum);
 	}
 }
-
+*/
 
 AEffect* VSTPluginMain(AudioMasterProc audioMasterProc)
 {

--- a/src/plugin/main.cpp
+++ b/src/plugin/main.cpp
@@ -33,9 +33,19 @@ void signalHandler(int signum)
 
 AEffect* VSTPluginMain(AudioMasterProc audioMasterProc)
 {
-	// FIXME Without this signal handler the Renoise tracker is unable to start the child
-	// winelib application.
-	signal(SIGCHLD, signalHandler);
+    /*  // FIXME Without this signal handler the Renoise tracker is unable to start the child
+        // winelib application.
+
+     This signal handler can cause issues if multiple airwave plugins are loaded since it
+     assigns an handler for the hole process. If the plugin is unloaded it should reassign
+     the handler otherwise the other plugins will crash.
+
+     For now this handler should be comment out. I've tested this with Renoise 3.2.0 and
+     this signal handler is not needed.
+
+        //signal(SIGCHLD, signalHandler);
+    */
+
 
 	Storage storage;
 	loggerInit(storage.logSocketPath(), PLUGIN_BASENAME);

--- a/src/plugin/plugin.cpp
+++ b/src/plugin/plugin.cpp
@@ -5,7 +5,7 @@
 #include <sys/wait.h>
 #include "common/logger.h"
 #include "common/protocol.h"
-
+#include "common/framequeue.h"
 
 #define XEMBED_EMBEDDED_NOTIFY	0
 #define XEMBED_FOCUS_OUT		5
@@ -39,7 +39,7 @@ Plugin::Plugin(const std::string& vstPath, const std::string& hostPath,
 	}
 
 	// FIXME: frame size should be verified.
-	if(!callbackPort_.create(1024)) {
+	if(!callbackPort_.create(FrameQueue::CALLBACK_FRAMESIZE)) {
 		ERROR("Unable to create callback port");
 		controlPort_.disconnect();
 		return;
@@ -94,6 +94,10 @@ Plugin::Plugin(const std::string& vstPath, const std::string& hostPath,
 		childPid_ = -1;
 		return;
 	}
+
+	// Asynchronous audio callback processor, we use the same memory IPC ID since we know
+	// it is unique on the system.
+	audioCallback_.connect(controlPort_.id());
 
 	PluginInfo* info = reinterpret_cast<PluginInfo*>(frame->data);
 	effect_ = new AEffect;
@@ -167,7 +171,7 @@ void Plugin::callbackThread()
 	while(processCallbacks_.test_and_set()) {
 		if(callbackPort_.waitRequest("Plugin::callbackThread", 100)) {
 			DataFrame* frame = callbackPort_.frame<DataFrame>();
-			frame->value = handleAudioMaster();
+			frame->value = handleAudioMaster(frame);
 			callbackPort_.sendResponse();
 		}
 	}
@@ -203,10 +207,8 @@ intptr_t Plugin::setBlockSize(DataPort* port, intptr_t frames)
 }
 
 
-intptr_t Plugin::handleAudioMaster()
+intptr_t Plugin::handleAudioMaster(DataFrame *frame)
 {
-	DataFrame* frame = callbackPort_.frame<DataFrame>();
-
 	if(frame->opcode != audioMasterGetTime && frame->opcode != audioMasterIdle) {
 		FLOOD("(%p) handleAudioMaster(opcode: %s, index: %d, value: %d, opt: %g)",
 				std::this_thread::get_id(), kAudioMasterEvents[frame->opcode],
@@ -714,6 +716,12 @@ void Plugin::processReplacing(float** inputs, float** outputs, i32 count)
 	audioPort_.sendRequest();
 	audioPort_.waitResponse("Plugin::processReplacing");
 
+	u8 callbackData[FrameQueue::CALLBACK_FRAMESIZE];
+	while ( audioCallback_.popFrame((DataFrame *) &callbackData) ) {
+		DEBUG("Processing async audioMaster call from audio thread");
+		handleAudioMaster((DataFrame *) &callbackData);
+	}
+
 	data = reinterpret_cast<float*>(frame->data);
 
 	for(int i = 0; i < effect_->numOutputs; ++i) {
@@ -735,6 +743,12 @@ void Plugin::processDoubleReplacing(double** inputs, double** outputs, i32 count
 
 	audioPort_.sendRequest();
 	audioPort_.waitResponse("Plugin::processDoubleReplacing");
+
+	u8 callbackData[FrameQueue::CALLBACK_FRAMESIZE];
+	while ( audioCallback_.popFrame((DataFrame *) &callbackData) ) {
+		DEBUG("Processing async audioMaster call from audio thread");
+		handleAudioMaster((DataFrame *) &callbackData);
+	}
 
 	data = reinterpret_cast<double*>(frame->data);
 

--- a/src/plugin/plugin.h
+++ b/src/plugin/plugin.h
@@ -11,7 +11,7 @@
 #include "common/event.h"
 #include "common/vst24.h"
 #include "common/vsteventkeeper.h"
-
+#include "common/framequeue.h"
 
 namespace Airwave {
 
@@ -47,6 +47,8 @@ private:
 	DataPort callbackPort_;
 	DataPort audioPort_;
 
+	FrameQueue audioCallback_;
+
 	Event condition_;
 
 	int childPid_;
@@ -68,7 +70,7 @@ private:
 
 	intptr_t setBlockSize(DataPort* port, intptr_t frames);
 
-	intptr_t handleAudioMaster();
+	intptr_t handleAudioMaster(DataFrame *frame);
 
 	intptr_t dispatch(DataPort* port, i32 opcode, i32 index, intptr_t value, void* ptr,
 			float opt);

--- a/src/tester/CMakeLists.txt
+++ b/src/tester/CMakeLists.txt
@@ -1,0 +1,32 @@
+set(TARGET_NAME ${PROJECT_NAME}-tester)
+
+project(${TARGET_NAME})
+
+find_package(LibMagic REQUIRED)
+find_package(Threads REQUIRED)
+
+include_directories(
+	${CMAKE_CURRENT_BINARY_DIR}
+	${CMAKE_CURRENT_SOURCE_DIR}
+	${VSTSDK_INCLUDE_DIR}
+)
+
+add_definitions(-D__cdecl=)
+
+set(SOURCES
+	../common/dataport.cpp
+	../common/event.cpp
+	../common/filesystem.cpp
+	../common/logger.cpp
+	../common/storage.cpp
+	../common/json.cpp
+	../common/filesystem.cpp
+	../common/moduleinfo.cpp
+	main.cpp
+)
+
+add_executable(${TARGET_NAME} ${SOURCES} ${HEADERS})
+
+target_link_libraries(${TARGET_NAME} ${LIBRARIES} ${LIBMAGIC_LIBRARY} ${CMAKE_THREAD_LIBS_INIT})
+
+install(TARGETS ${TARGET_NAME} RUNTIME DESTINATION bin)

--- a/src/tester/main.cpp
+++ b/src/tester/main.cpp
@@ -1,0 +1,253 @@
+#include <stdio.h>
+#include <cstring>
+#include <thread>
+#include <unistd.h>
+#include <sys/wait.h>
+
+#include "common/logger.h"
+#include "common/protocol.h"
+#include "common/framequeue.h"
+#include "common/dataport.h"
+#include "common/event.h"
+#include "common/storage.h"
+#include "common/filesystem.h"
+#include "common/moduleinfo.h"
+#include "common/config.h"
+#include "common/vst24.h"
+
+using namespace Airwave;
+
+namespace Airwave {
+
+struct AirwaveTester {
+	Airwave::DataPort controlPort_;
+	DataPort audioPort_;
+	FrameQueue audioCallback_;
+	Event condition_;
+	int childPid_;
+	std::thread callbackThread_;
+	Airwave::DataPort callbackPort_;
+	AEffect* effect_;
+	std::atomic_flag processCallbacks_;
+
+	AirwaveTester(const std::string& vstPath, const std::string& hostPath,
+		const std::string& prefixPath, const std::string& loaderPath,
+		const std::string& logSocketPath) :
+	  processCallbacks_(ATOMIC_FLAG_INIT) {
+		
+		// FIXME: frame size should be verified.
+		if(!controlPort_.create(65536)) {
+			printf("Unable to create control port\n");
+			return;
+		}
+
+		// FIXME: frame size should be verified.
+		if(!callbackPort_.create(FrameQueue::CALLBACK_FRAMESIZE)) {
+			printf("Unable to create callback port\n");
+			controlPort_.disconnect();
+			return;
+		}
+
+		// Start the host endpoint's process.
+		childPid_ = fork();
+		if(childPid_ == -1) {
+			printf("fork() call failed\n");
+			controlPort_.disconnect();
+			callbackPort_.disconnect();
+			return;
+		}
+		else if(childPid_ == 0) {
+			setenv("WINEPREFIX", prefixPath.c_str(), 1);
+			setenv("WINELOADER", loaderPath.c_str(), 1);
+
+			std::string id = std::to_string(controlPort_.id());
+			std::string level = std::to_string(static_cast<int>(loggerLogLevel()));
+
+			execl("/bin/sh", "/bin/sh", hostPath.c_str(), vstPath.c_str(), id.c_str(),
+					level.c_str(), logSocketPath.c_str(), nullptr);
+
+			// We should never reach this point on success child execution.
+			printf("execl() call failed\n");
+			return;
+		}
+
+		printf("Child process started, pid=%d\n", childPid_);
+
+		processCallbacks_.test_and_set();
+		callbackThread_ = std::thread(&AirwaveTester::callback, this);
+
+		condition_.wait();
+
+		// Send host info to the host endpoint.
+		DataFrame* frame = controlPort_.frame<DataFrame>();
+		frame->command = Command::HostInfo;
+		frame->opcode = callbackPort_.id();
+		controlPort_.sendRequest();
+
+		printf("Waiting response from host endpoint...\n");
+
+		// Wait for the host endpoint initialization.
+		if(!controlPort_.waitResponse("Plugin::Plugin")) {
+			printf("Host endpoint is not responding\n");
+			kill(childPid_, SIGKILL);
+			controlPort_.disconnect();
+			callbackPort_.disconnect();
+			childPid_ = -1;
+			return;
+		}
+
+		audioCallback_.connect(controlPort_.id());
+
+		PluginInfo* info = reinterpret_cast<PluginInfo*>(frame->data);
+		effect_ = new AEffect;
+		std::memset(effect_, 0, sizeof(AEffect));
+
+		effect_->magic                  = kEffectMagic;
+		effect_->object                 = this;
+		effect_->__processDeprecated    = nullptr;
+		effect_->flags                  = info->flags;
+		effect_->numPrograms            = info->programCount;
+		effect_->numParams              = info->paramCount;
+		effect_->numInputs              = info->inputCount;
+		effect_->numOutputs             = info->outputCount;
+		effect_->initialDelay           = info->initialDelay;
+		effect_->uniqueID               = info->uniqueId;
+		effect_->version                = info->version;
+
+		printf("VST plugin summary:\n");
+		printf("  flags:         0x%08X\n", effect_->flags);
+		printf("  program count: %d\n",     effect_->numPrograms);
+		printf("  param count:   %d\n",     effect_->numParams);
+		printf("  input count:   %d\n",     effect_->numInputs);
+		printf("  output count:  %d\n",     effect_->numOutputs);
+		printf("  initial delay: %d\n",     effect_->initialDelay);
+		printf("  unique ID:     0x%08X\n", effect_->uniqueID);
+		printf("  version:       %d\n",     effect_->version);
+	}
+
+	~AirwaveTester() {
+		processCallbacks_.clear();
+		if(callbackThread_.joinable())
+			callbackThread_.join();
+
+		controlPort_.disconnect();
+		callbackPort_.disconnect();
+		audioPort_.disconnect();
+
+		int status;
+		waitpid(childPid_, &status, 0);
+		printf("Tester done for plugin.\n");		
+	}
+
+	intptr_t handleAudioMaster(DataFrame *frame) {
+		printf("Plugin called API: handleAudioMaster -");
+		switch(frame->opcode) {
+		case audioMasterVersion:
+			printf("audioMasterVersion\n");
+			return 2400;
+		default:
+			printf("unknown event %s %d\n", kAudioMasterEvents[frame->opcode], frame->opcode);			
+		}
+
+		return 0;
+	}
+
+	void callback() {
+		condition_.post();
+		while(processCallbacks_.test_and_set()) {
+			if(callbackPort_.waitRequest("Plugin::callbackThread", 100)) {
+				DataFrame* frame = callbackPort_.frame<DataFrame>();
+				frame->value = handleAudioMaster(frame);
+				callbackPort_.sendResponse();
+			}
+		}
+	}
+};
+
+}
+
+int main(int argc, char *argv[]) {
+	if (argc < 2 ) {
+		printf("Usage: airwave-tester [path of linux airwave VST wrapper]\n");
+		return 1;
+	}
+
+	Storage storage;
+	std::string filePath = FileSystem::realPath(argv[1]);
+
+	if(filePath.empty()) {
+		printf("Unable to get an absolute path of the plugin binary\n");
+		return 1;
+	}
+
+	Storage::Link link = storage.link(filePath);
+	if(!link) {
+		printf("Link '%s' is corrupted\n", filePath.c_str());
+		return 1;
+	}
+
+	printf("Plugin binary: %s\n", filePath.c_str());
+
+	std::string winePrefix = link.prefix();
+	Storage::Prefix prefix = storage.prefix(winePrefix);
+	if(!prefix) {
+		printf("Invalid WINE prefix '%s'\n", winePrefix.c_str());
+		return 1;
+	}
+
+	std::string prefixPath = FileSystem::realPath(prefix.path());
+	if(!FileSystem::isDirExists(prefixPath)) {
+		printf("WINE prefix directory '%s' doesn't exists\n", prefixPath.c_str());
+		return 1;
+	}
+
+	printf("WINE prefix:   %s\n", prefixPath.c_str());
+
+	std::string wineLoader = link.loader();
+	Storage::Loader loader = storage.loader(wineLoader);
+	if(!loader) {
+		printf("Invalid WINE loader '%s'\n", wineLoader.c_str());
+		return 1;
+	}
+
+	std::string loaderPath = FileSystem::realPath(loader.path());
+	if(!FileSystem::isFileExists(loaderPath)) {
+		printf("WINE loader binary '%s' doesn't exists\n", loaderPath.c_str());
+		return 1;
+	}	
+
+	printf("WINE loader:   %s\n", loaderPath.c_str());
+
+	std::string vstPath = prefixPath + '/' + link.target();
+	if(!FileSystem::isFileExists(vstPath)) {
+		printf("VST binary '%s' doesn't exists\n", vstPath.c_str());
+		return 1;
+	}
+
+	printf("VST binary:    %s\n", vstPath.c_str());
+
+	// Find host binary path
+	ModuleInfo::Arch arch = ModuleInfo::instance()->getArch(vstPath);
+
+	std::string hostName;
+	if(arch == ModuleInfo::kArch64) {
+		hostName = HOST_BASENAME "-64.exe";
+	}
+	else if(arch == ModuleInfo::kArch32) {
+		hostName = HOST_BASENAME "-32.exe";
+	}
+	else {
+		printf("Unable to determine VST plugin architecture\\n");
+		return 1;
+	}
+
+	std::string hostPath = FileSystem::realPath(storage.binariesPath() + '/' + hostName);
+	if(!FileSystem::isFileExists(hostPath)) {
+		printf("Host binary '%s' doesn't exists\n", hostPath.c_str());
+		return 1;
+	}
+
+	printf("Host binary:   %s\n", hostPath.c_str());
+
+	AirwaveTester tester(vstPath, hostPath, prefixPath, loaderPath, storage.logSocketPath());
+}

--- a/src/tester/main.cpp
+++ b/src/tester/main.cpp
@@ -140,7 +140,7 @@ struct AirwaveTester {
 	}
 
 	intptr_t handleAudioMaster(DataFrame *frame) {
-		printf("Plugin called API: handleAudioMaster -");
+		printf("Plugin called API: handleAudioMaster - ");
 		switch(frame->opcode) {
 		case audioMasterVersion:
 			printf("audioMasterVersion\n");


### PR DESCRIPTION
Fixed audio thread deadlock when audioMasterProcessEvents was generated from the plugin audio thread. audioMasterProcessEvents are now process async to avoid thread switching from the host/vst plugin.

Fixed issue upon X11 async message that causes plugin to hang host. Also fixed multiple airwave plugin that crash on unload if it was not in the right order.

